### PR TITLE
Add MutuallyExclusive callback group to camera subscribers

### DIFF
--- a/robot_calibration/src/finders/checkerboard_finder.cpp
+++ b/robot_calibration/src/finders/checkerboard_finder.cpp
@@ -54,7 +54,7 @@ bool CheckerboardFinder::init(const std::string& name,
   subscription_options.callback_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   subscriber_ = node->create_subscription<sensor_msgs::msg::PointCloud2>(
     topic_name,
-    rclcpp::SensorDataQoS(),
+    rclcpp::SensorDataQoS().reliable(),
     std::bind(&CheckerboardFinder::cameraCallback, this, std::placeholders::_1),
     subscription_options);
 

--- a/robot_calibration/src/finders/checkerboard_finder.cpp
+++ b/robot_calibration/src/finders/checkerboard_finder.cpp
@@ -50,10 +50,13 @@ bool CheckerboardFinder::init(const std::string& name,
   // Setup subscriber
   std::string topic_name;
   topic_name = node->declare_parameter<std::string>(name + ".topic", name + "/points");
+  auto subscription_options = rclcpp::SubscriptionOptions();
+  subscription_options.callback_group = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   subscriber_ = node->create_subscription<sensor_msgs::msg::PointCloud2>(
     topic_name,
-    rclcpp::QoS(1).best_effort().keep_last(1),
-    std::bind(&CheckerboardFinder::cameraCallback, this, std::placeholders::_1));
+    rclcpp::SensorDataQoS(),
+    std::bind(&CheckerboardFinder::cameraCallback, this, std::placeholders::_1),
+    subscription_options);
 
   RCLCPP_ERROR(LOGGER, "Name: %s, Subscribing to: %s", name.c_str(), topic_name.c_str());
 


### PR DESCRIPTION
This PR fixes the node locking up when subscribing to camera data. 

NOTE: there are other subscribers in the library that are not being used right now that will also suffer from this issue.